### PR TITLE
Initial Storage Build

### DIFF
--- a/pallets/popi/src/lib.rs
+++ b/pallets/popi/src/lib.rs
@@ -32,6 +32,13 @@ pub mod pallet {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// Type representing the weight of this pallet
 		type WeightInfo: WeightInfo;
+		/// This is the amount of experience that a user needs to level up the first time
+		/// In addition, this will impact the amount of experience required to level up in the future
+		type BaseExperience: Get<u128>;
+		/// Represents the overall difficulty of leveling up
+		type LevelDifficulty: Get<u32>;
+		/// The multiplier for the amount of experience required to level up
+		type DifficultMultiplier: Get<u32>;
 	}
 
 	// The pallet's runtime storage items.
@@ -91,18 +98,18 @@ pub mod pallet {
 	pub struct UserExperience<T: Config> {
 		/// The user's account id
 		/// This allows for querying of user's with specific experience thresholds
-		account_id: T::AccountId,
+		pub account_id: T::AccountId,
 		/// The user's experience
-		experience: u128,
+		pub experience: u128,
 		/// The user's experience level
 		/// This is calculated from the user's experience
-		level: u32,
+		pub level: u32,
 		/// Experience required to reach the next level
 		/// This is calculated from the user's experience
-		experience_to_next_level: u128,
+		pub experience_to_next_level: u128,
 		/// Type of experience that this is referring to
 		/// Eg. Frontend, Backend, Marketing, Graphic Design, etc.
-		type_of_experience: ExperienceType,
+		pub type_of_experience: ExperienceType,
 	}
 
 	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
@@ -155,19 +162,23 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Creates a new user experience, based on experience type and user id
 		/// Returns an error if the user already has experience
-		// fn create_user_experience(user: T::AccountId) -> DispatchResult {
-		// 	// Check if the user already has experience
-		// 	ExperienceStorage::<T>::get(user).ok_or(Error::<T>::UserAlreadyHasExperience.into())?;
+		fn create_user_experience(user: T::AccountId) -> DispatchResult {
+			// Check if the user already has experience
+			if ExperienceStorage::<T>::contains_key(&user) {
+				return Err(Error::<T>::UserAlreadyHasExperience.into());
+			}
 
-		// 	// Create a new user experience
-		// 	let new_user_experience = UserExperience {
-		// 		account_id: user,
-		// 		experience: 0,
-		// 		level: 0,
-		// 		experience_to_next_level: 100,
-		// 		type_of_experience: ExperienceType::Frontend,
-		// 	};
-		// }
+			// Create a new user experience
+			let new_user_experience = UserExperience::<T> {
+				account_id: user,
+				experience: 0,
+				level: 0,
+				experience_to_next_level: 100,
+				type_of_experience: ExperienceType::Frontend,
+			};
+
+			Ok(())
+		}
 
 		/// Takes in a user id and returns the user's experience if it exists, otherwise returns an error
 		fn get_user_experience(user: T::AccountId) -> DispatchResult {

--- a/pallets/popi/src/lib.rs
+++ b/pallets/popi/src/lib.rs
@@ -27,7 +27,7 @@ pub mod pallet {
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	///
-	/// For additional information on BaseExperience, LevelDifficulty, and DifficultMultiplier, check `fn calculate_exp_to_next_level`.
+	/// For additional information on BaseExperience, LevelDifficulty, and DifficultyMultiplier, check `fn calculate_exp_to_next_level`.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
@@ -43,7 +43,16 @@ pub mod pallet {
 		type LevelDifficulty: Get<u32>;
 		#[pallet::constant]
 		/// The multiplier for the amount of experience required to level up
-		type DifficultMultiplier: Get<u32>;
+		type DifficultyMultiplier: Get<u32>;
+
+		/*
+		level 1: 100
+		level 2: 200
+		level 3: 400
+		level 4: 800
+		level 5: 1600
+		BaseExperience * DifficultyMultiplier ^ (LevelDifficulty * (level - 1))
+		 */
 	}
 
 	// The pallet's runtime storage items.

--- a/pallets/popi/src/lib.rs
+++ b/pallets/popi/src/lib.rs
@@ -19,24 +19,29 @@ pub use weights::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::{*, DispatchResult};
+	use frame_support::pallet_prelude::{DispatchResult, *};
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
+	///
+	/// For additional information on BaseExperience, LevelDifficulty, and DifficultMultiplier, check `fn calculate_exp_to_next_level`.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// Type representing the weight of this pallet
 		type WeightInfo: WeightInfo;
+		#[pallet::constant]
 		/// This is the amount of experience that a user needs to level up the first time
 		/// In addition, this will impact the amount of experience required to level up in the future
 		type BaseExperience: Get<u128>;
+		#[pallet::constant]
 		/// Represents the overall difficulty of leveling up
 		type LevelDifficulty: Get<u32>;
+		#[pallet::constant]
 		/// The multiplier for the amount of experience required to level up
 		type DifficultMultiplier: Get<u32>;
 	}
@@ -51,12 +56,8 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn storage_getter)]
-	pub type ExperienceStorage<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat, //hashing algorithm
-		T::AccountId,     //key
-		(),               //value
-	>;
+	pub type ExperienceStorage<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, UserExperience<T>>;
 
 	//pub type ListOfThings<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, ()>;
 	// Pallets use events to inform users when important changes are made.
@@ -83,7 +84,7 @@ pub mod pallet {
 		UserAlreadyHasExperience,
 	}
 
-
+	#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug)]
 	/// This enum represents the different types of experience that a user can have
 	/// Ideally, we want to this to be extensible so that we can add more types of experience
 	pub enum ExperienceType {
@@ -93,6 +94,8 @@ pub mod pallet {
 		GraphicDesign,
 	}
 
+	#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug)]
+	#[scale_info(skip_type_params(T))]
 	/// This struct represents the a user's experience
 	/// Due to the types of experience that a user can have
 	pub struct UserExperience<T: Config> {
@@ -162,19 +165,19 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Creates a new user experience, based on experience type and user id
 		/// Returns an error if the user already has experience
-		fn create_user_experience(user: T::AccountId) -> DispatchResult {
+		fn create_user_experience(user: T::AccountId, exp_type: ExperienceType) -> DispatchResult {
 			// Check if the user already has experience
 			if ExperienceStorage::<T>::contains_key(&user) {
 				return Err(Error::<T>::UserAlreadyHasExperience.into());
 			}
 
 			// Create a new user experience
-			let new_user_experience = UserExperience::<T> {
+			let new_user_exp = UserExperience::<T> {
 				account_id: user,
 				experience: 0,
 				level: 0,
-				experience_to_next_level: 100,
-				type_of_experience: ExperienceType::Frontend,
+				experience_to_next_level: T::BaseExperience::get(),
+				type_of_experience: exp_type,
 			};
 
 			Ok(())
@@ -182,7 +185,23 @@ pub mod pallet {
 
 		/// Takes in a user id and returns the user's experience if it exists, otherwise returns an error
 		fn get_user_experience(user: T::AccountId) -> DispatchResult {
-			ExperienceStorage::<T>::get(user).ok_or(Error::<T>::ValueDoesNotExist.into())
+			// ExperienceStorage::<T>::get(user).ok_or(Error::<T>::ValueDoesNotExist.into());
+			unimplemented!()
+		}
+
+		fn update_user_experience(
+			user: T::AccountId,
+			experience: UserExperience<T>,
+		) -> DispatchResult {
+			unimplemented!()
+		}
+
+		/// Usees our Config types to calculate the amount of experience required to level up
+		fn calculate_exp_to_next_level(
+			experience: UserExperience<T>,
+			level: u32,
+		) -> DispatchResult {
+			unimplemented!()
 		}
 	}
 }

--- a/pallets/popi/src/lib.rs
+++ b/pallets/popi/src/lib.rs
@@ -19,7 +19,7 @@ pub use weights::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
+	use frame_support::pallet_prelude::{*, DispatchResult};
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
@@ -44,12 +44,13 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn storage_getter)]
-	pub type SampleUnitStorage<T: Config> = StorageMap<
+	pub type ExperienceStorage<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat, //hashing algorithm
 		T::AccountId,     //key
 		(),               //value
 	>;
+
 	//pub type ListOfThings<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, ()>;
 	// Pallets use events to inform users when important changes are made.
 	// https://docs.substrate.io/main-docs/build/events-errors/
@@ -68,6 +69,40 @@ pub mod pallet {
 		NoneValue,
 		/// Errors should have helpful documentation associated with them.
 		StorageOverflow,
+		/// Desired value does not exist in ExdperienceStorage
+		ValueDoesNotExist,
+		/// User already has experience
+		/// This error is thrown when a user tries to create a new experience when they already have one
+		UserAlreadyHasExperience,
+	}
+
+
+	/// This enum represents the different types of experience that a user can have
+	/// Ideally, we want to this to be extensible so that we can add more types of experience
+	pub enum ExperienceType {
+		Frontend,
+		Backend,
+		Marketing,
+		GraphicDesign,
+	}
+
+	/// This struct represents the a user's experience
+	/// Due to the types of experience that a user can have
+	pub struct UserExperience<T: Config> {
+		/// The user's account id
+		/// This allows for querying of user's with specific experience thresholds
+		account_id: T::AccountId,
+		/// The user's experience
+		experience: u128,
+		/// The user's experience level
+		/// This is calculated from the user's experience
+		level: u32,
+		/// Experience required to reach the next level
+		/// This is calculated from the user's experience
+		experience_to_next_level: u128,
+		/// Type of experience that this is referring to
+		/// Eg. Frontend, Backend, Marketing, Graphic Design, etc.
+		type_of_experience: ExperienceType,
 	}
 
 	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
@@ -112,6 +147,31 @@ pub mod pallet {
 					Ok(())
 				},
 			}
+		}
+	}
+
+	/// The following impl and functions should not be accessible by the user
+	/// For any function that needs to be accessible by the user, use the above implementation (under #[pallet::call] attribute)
+	impl<T: Config> Pallet<T> {
+		/// Creates a new user experience, based on experience type and user id
+		/// Returns an error if the user already has experience
+		// fn create_user_experience(user: T::AccountId) -> DispatchResult {
+		// 	// Check if the user already has experience
+		// 	ExperienceStorage::<T>::get(user).ok_or(Error::<T>::UserAlreadyHasExperience.into())?;
+
+		// 	// Create a new user experience
+		// 	let new_user_experience = UserExperience {
+		// 		account_id: user,
+		// 		experience: 0,
+		// 		level: 0,
+		// 		experience_to_next_level: 100,
+		// 		type_of_experience: ExperienceType::Frontend,
+		// 	};
+		// }
+
+		/// Takes in a user id and returns the user's experience if it exists, otherwise returns an error
+		fn get_user_experience(user: T::AccountId) -> DispatchResult {
+			ExperienceStorage::<T>::get(user).ok_or(Error::<T>::ValueDoesNotExist.into())
 		}
 	}
 }

--- a/pallets/popi/src/mock.rs
+++ b/pallets/popi/src/mock.rs
@@ -50,7 +50,10 @@ impl frame_system::Config for Test {
 
 impl pallet_popi::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
+	type WeightInfo = pallet_popi::weights::SubstrateWeight<Runtime>;
+	type BaseExperience = ConstU128<100>;
+	type LevelDifficulty = ConstU32<10>;
+	type DifficultMultiplier = ConstU32<2>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/popi/src/mock.rs
+++ b/pallets/popi/src/mock.rs
@@ -1,6 +1,6 @@
 use crate as pallet_popi;
 use frame_support::traits::{ConstU16, ConstU64};
-use sp_core::H256;
+use sp_core::{H256, ConstU128, ConstU32};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -17,7 +17,7 @@ frame_support::construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		System: frame_system,
-		PopiModule: pallet_popi,
+		Popi: pallet_popi,
 	}
 );
 
@@ -50,7 +50,7 @@ impl frame_system::Config for Test {
 
 impl pallet_popi::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = pallet_popi::weights::SubstrateWeight<Runtime>;
+	type WeightInfo = ();
 	type BaseExperience = ConstU128<100>;
 	type LevelDifficulty = ConstU32<10>;
 	type DifficultMultiplier = ConstU32<2>;

--- a/pallets/popi/src/mock.rs
+++ b/pallets/popi/src/mock.rs
@@ -53,7 +53,7 @@ impl pallet_popi::Config for Test {
 	type WeightInfo = ();
 	type BaseExperience = ConstU128<100>;
 	type LevelDifficulty = ConstU32<10>;
-	type DifficultMultiplier = ConstU32<2>;
+	type DifficultyMultiplier = ConstU32<2>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/popi/src/tests.rs
+++ b/pallets/popi/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, Error, Event};
+use crate::{mock::*, Error, Event, ExperienceType};
 use frame_support::{assert_noop, assert_ok};
 #[test]
 fn i_know_how_to_work_with_vectors() {}
@@ -9,9 +9,9 @@ fn it_works_for_default_value() {
 		// Go past genesis block so events get deposited
 		System::set_block_number(1);
 		// Dispatch a signed extrinsic.
-		assert_ok!(PopiModule::do_something(RuntimeOrigin::signed(1), 42));
+		assert_ok!(Popi::do_something(RuntimeOrigin::signed(1), 42));
 		// Read pallet storage and assert an expected result.
-		assert_eq!(PopiModule::something(), Some(42));
+		assert_eq!(Popi::something(), Some(42));
 		// Assert that the correct event was deposited
 		System::assert_last_event(Event::SomethingStored { something: 42, who: 1 }.into());
 	});
@@ -21,6 +21,28 @@ fn it_works_for_default_value() {
 fn correct_error_for_none_value() {
 	new_test_ext().execute_with(|| {
 		// Ensure the expected error is thrown when no value is present.
-		assert_noop!(PopiModule::cause_error(RuntimeOrigin::signed(1)), Error::<Test>::NoneValue);
+		assert_noop!(Popi::cause_error(RuntimeOrigin::signed(1)), Error::<Test>::NoneValue);
+	});
+}
+
+#[test]
+fn create_user_experiences() {
+	new_test_ext().execute_with(|| {
+		let account_id = 42;
+		let exp_type = ExperienceType::Backend;
+
+		// User exp has not been set yet, so it should return an error
+		assert!(Popi::get_user_experience(account_id, exp_type).is_err());
+		// Successfully create a new user experience
+		assert_ok!(Popi::create_user_experience(account_id, exp_type.clone()));
+		// Should not allow the duplicate creation of user experience
+		assert_noop!(
+			Popi::create_user_experience(account_id, exp_type),
+			Error::<Test>::UserAlreadyHasExperience
+		);
+		// Successfully get the user experience
+		assert_ok!(Popi::get_user_experience(account_id, exp_type));
+		// Should not allow the creation of user experience for a different type that does not exist
+		assert!(Popi::get_user_experience(account_id, ExperienceType::Frontend).is_err());
 	});
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -273,7 +273,7 @@ impl pallet_popi::Config for Runtime {
 	type WeightInfo = pallet_popi::weights::SubstrateWeight<Runtime>;
 	type BaseExperience = ConstU128<100>;
 	type LevelDifficulty = ConstU32<10>;
-	type DifficultMultiplier = ConstU32<2>;
+	type DifficultyMultiplier = ConstU32<2>;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -271,6 +271,9 @@ impl pallet_sudo::Config for Runtime {
 impl pallet_popi::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_popi::weights::SubstrateWeight<Runtime>;
+	type BaseExperience = ConstU128<100>;
+	type LevelDifficulty = ConstU32<10>;
+	type DifficultMultiplier = ConstU32<2>;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
### Initial Goal
To create a storage that stores the "experience" a user has. 

### Design choices
Due to our emphasis on creating "experiences" that **only** benefit developers, I decided to create an enum which represents the types of experiences. Eg. frontend, backend, marketing, graphic design, etc. With this current design, a unique storage value is created with a key pair (account ID and experience type). This allows each user to gain experience in specific areas. 

> Here were my thoughts behind this:
> - Every task should be rewarded, regardless of the type of work done.
> - Rather than determining which "types" of work are more valuable, we can use the same experience logic for every type (represented as an enum). This will allow experience to represent the amount of expertise someone has in a given area.
> - Whether users should be able to add enum values is uncertain. This would require some more thought on how to monitor this.

### Next steps
- Set an initial leveling formula (the beginning of one can be found in the code, which I began planning for).
  - It will store **total** experience **and** level rather than just the level **and** experience required for the next level. This will allow for easy adjustments in case the formula changes later on in production. It will allow for an easy calculation of a levels in case the logic changes.

